### PR TITLE
fix: transition function wrapper does not execute action if view transition API is not supported

### DIFF
--- a/src/routes/planets/[planet]/button.svelte
+++ b/src/routes/planets/[planet]/button.svelte
@@ -4,7 +4,10 @@
 
 	function transition(action: () => void) {
 		// @ts-ignore
-		if (!document.startViewTransition) return
+		if (!document.startViewTransition) {
+			action()
+			return
+		}
 		// @ts-ignore
 		document.startViewTransition(action)
 	}


### PR DESCRIPTION
If `startViewTransitions`  is not supported, the action is never run.

This pull request fixes the button transition in browsers that do not support the `startViewTransition` yet.

Tested in firefox.